### PR TITLE
Prevent Job Creation without Required Task

### DIFF
--- a/analytics_automated/tests/example_cwl_file/task2.cwl
+++ b/analytics_automated/tests/example_cwl_file/task2.cwl
@@ -10,8 +10,6 @@ outputs:
   output1:
     type: stdout
 stdout: output.txt
-requirements:
-  - class: InlineJavascriptRequirement
 arguments: ["--verbose"]
 stdin: $(inputs.input1.path)
 successCodes: [0]

--- a/analytics_automated/tests/example_cwl_file/task3.cwl
+++ b/analytics_automated/tests/example_cwl_file/task3.cwl
@@ -20,7 +20,6 @@ requirements:
     listing:
       - entryname: "tempfile.txt"
         entry: $(inputs.files[0].path)
-  - class: InlineJavascriptRequirement
 successCodes: [0]
 temporaryFailCodes: [1]
 permanentFailCodes: [2]

--- a/analytics_automated/views.py
+++ b/analytics_automated/views.py
@@ -33,6 +33,7 @@ class CWLUploadPageView(View):
         
         # Parse each CWL file
         try:
+            workflow_files_temp = {}
             workflow_files = {}
             for file_name, full_path in file_paths.items():
                 with open(full_path, 'r') as cwl_file:
@@ -40,13 +41,20 @@ class CWLUploadPageView(View):
                 cwl_class = cwl_data.get("class")
 
                 if cwl_class == "Workflow":
+                    workflow_files_temp[file_name] = cwl_data
+                elif cwl_class == "CommandLineTool":
                     workflow_files[file_name] = cwl_data
+            
+            # Put workflow file at the end of the list
+            for file_name, cwl_data in workflow_files_temp.items():
+                workflow_files[file_name] = cwl_data
 
             if not workflow_files:
                 messages.append("No workflow files found in the uploaded files.")
             else:
-                for workflow_name, workflow_data in workflow_files.items():
-                    read_cwl_file(file_paths[workflow_name], file_paths, messages)
+                for workflow_name in workflow_files:
+                    filename = workflow_name.split('.')[0]
+                    read_cwl_file(file_paths[workflow_name], filename, messages)
             
             # Clean up uploaded files
             for file_name, full_path in file_paths.items():


### PR DESCRIPTION
# Changes:
1. Create all tasks first before job
2. Check if all tasks in job steps are exist
    a. If not, cancel job creation
    b. If yes, create job. Then, map job and task into step table

# Example:

https://github.com/waleedev01/analytics_automated_v2/assets/60391674/18b6941a-fef4-49c5-98c6-dc111ddd719d

