### PR TITLE
Fix Env Variable Update Procedure

### DIFF
--- a/analytics_automated/cwl_utils/cwl_clt_handler.py
+++ b/analytics_automated/cwl_utils/cwl_clt_handler.py
@@ -297,6 +297,22 @@ def save_task_to_db(task_data, messages):
             backend=backend,
         ).first()
 
+        # Check if the environments is a dictionary or a list
+        environments = task_data['environments']
+        if isinstance(environments, dict):
+            environment_items = environments.items()
+        elif isinstance(environments, list):
+            env_dict = {}
+            for env in environments:
+                if not isinstance(env, dict):
+                    messages.append("Environment variables should be a dictionary")
+                    return None
+                env_dict[env.get('envName')] = env.get('envValue')
+            environment_items = env_dict.items()
+        else:
+            messages.append("Environment variables should be a dictionary or a list")
+            return None
+
         if existing_task:
             message = f"Found existing task with name: {existing_task}"
             logging.info(message)
@@ -365,7 +381,7 @@ def save_task_to_db(task_data, messages):
             except Exception as e:
                 logging.error(f"Error saving parameter for task {task_data['name']}: {e}")
 
-        for env_var_name, env_var_value in task_data['environments'].items():
+        for env_var_name, env_var_value in environment_items:
             try:
                 # TODO: There are values that dynamic generated during CWL execution,
                 #  should be handled during Celery execution. (For example: $(inputs.message))

--- a/analytics_automated/cwl_utils/cwl_clt_handler.py
+++ b/analytics_automated/cwl_utils/cwl_clt_handler.py
@@ -37,21 +37,6 @@ def handle_env_variable_req(requirements: list) -> dict[str, str]:
         logging.error(f"Error handling environment variable requirements: {e}")
     return {}
 
-
-def filter_workflow_req(requirements):
-    """
-    Remove requirement should not be inherited by task
-    """
-    logging.info(f"Filtering workflow requirements: {requirements}")
-    try:
-        return list(filter(lambda req: req['class'] not in ['ScatterFeatureRequirement',
-                                                            'SubworkflowFeatureRequirement'],
-                           requirements))
-    except Exception as e:
-        logging.error(f"Error filtering workflow requirements: {e}")
-        return []
-
-
 def parse_cwl_clt(cwl_data, name, workflow_req: list = None):
     def map_format(format_uri, mapping):
         logging.info(f"Mapping format URI: {format_uri}")
@@ -98,19 +83,6 @@ def parse_cwl_clt(cwl_data, name, workflow_req: list = None):
         except Exception as e:
             logging.error(f"Error parsing CWL outputs: {e}")
         return parsed_outputs
-
-    def update_dict_with_no_conflict(original: dict, updates: dict) -> dict:
-        """
-        Update the task env variable with values from the workflow, without overwriting existing env variables.
-        """
-        logging.info(f"Updating dictionary with no conflict. Original: {original}, Updates: {updates}")
-        try:
-            for key, value in updates.items():
-                if key not in original:
-                    original[key] = value
-        except Exception as e:
-            logging.error(f"Error updating dictionary with no conflict: {e}")
-        return original
 
     def dynamic_value_judge(input_li: list, max_out: int, value: str) -> str:
         try:
@@ -193,13 +165,6 @@ def parse_cwl_clt(cwl_data, name, workflow_req: list = None):
         "custom_exit_status": custom_exit_status,
         "custom_exit_behaviour": custom_exit_behaviour,
     }
-
-    # Inherit Requirement from workflow
-    if workflow_req:
-        logging.info(f"Inheriting requirements from workflow: {workflow_req}")
-        inherited_req = filter_workflow_req(workflow_req)
-        inherited_env_var_li = handle_env_variable_req(inherited_req)
-        update_dict_with_no_conflict(original=task['environments'], updates=inherited_env_var_li)
 
     if stdout:
         task['stdout_glob'] = f".{stdout.split('.')[-1]}"

--- a/analytics_automated/cwl_utils/cwl_schema_validator.py
+++ b/analytics_automated/cwl_utils/cwl_schema_validator.py
@@ -68,6 +68,9 @@ class CWLSchemaValidator:
             if not inputs:
                 errors.append("Missing 'inputs' in CWL file")
             else:
+                if not isinstance(inputs, dict):
+                    errors.append("Please define inputs in CWL as dictionary")
+
                 for input_name, input_data in inputs.items():
                     if 'type' not in input_data:
                         errors.append(f"Missing 'type' for input '{input_name}'")
@@ -77,6 +80,9 @@ class CWLSchemaValidator:
             if not outputs:
                 errors.append("Missing 'outputs' in CWL file")
             else:
+                if not isinstance(outputs, dict):
+                    errors.append("Please define outputs in CWL as dictionary")
+                    
                 for output_name, output_data in outputs.items():
                     if 'type' not in output_data:
                         errors.append(f"Missing 'type' for output '{output_name}'")

--- a/analytics_automated/cwl_utils/cwl_workflow_handler.py
+++ b/analytics_automated/cwl_utils/cwl_workflow_handler.py
@@ -65,7 +65,7 @@ def parse_cwl_workflow(cwl_data, filename, messages):
             messages.append(error_message)
             return
 
-        task_arr.append(step_name)
+        task_arr.append(task.name)
 
     # Check for circular dependencies
     for step_name, source_list in step_source.items():

--- a/analytics_automated/cwl_utils/cwl_workflow_handler.py
+++ b/analytics_automated/cwl_utils/cwl_workflow_handler.py
@@ -48,8 +48,10 @@ def parse_cwl_workflow(cwl_data, filename, messages):
             elif isinstance(task_run, str):
                 if not task_run.endswith(".cwl"):
                     task_run += ".cwl"
+                    
+                task_name = task_run.split(".cwl")[0]
 
-                task = check_existing_task_in_db(step_name, messages)
+                task = check_existing_task_in_db(task_name, messages)
                 if task:
                     step_source[step_name] = set(source_arr)
                 else:


### PR DESCRIPTION
**Changes:**
1. Not saving task to database with invalid envVar or parameter
2. Use task name inside `run` field to search task in database
3. Env Variable create/update
a. Single CLT file ✅ 
b. Workflow with inline CLT ✅ 
c. Separate workflow and CLT ✅ 
d. Submit `b` or `c`, then update CLT file -> Task will only have the latest CLT Env Variable (the inherited workflow Env Variable will be removed) ✅
