### PR TITLE
Special Case that do not add $I

### DIFF
--- a/analytics_automated/cwl_utils/cwl_clt_handler.py
+++ b/analytics_automated/cwl_utils/cwl_clt_handler.py
@@ -134,7 +134,7 @@ def parse_cwl_clt(cwl_data, name, workflow_req: list = None):
             if "$O" in value:
                 if len(value) < 3 or not value[2].isdigit():
                     raise ValueError(f"Missing Output index in {value}")
-                if value[2] > max_out:
+                if int(value[2]) > max_out:
                     raise IndexError(f"Only {max_out} in the task, index {value[2]} does not exist")
             return value
         except Exception as e:

--- a/analytics_automated/tests/example_cwl_files/epestfind.cwl
+++ b/analytics_automated/tests/example_cwl_files/epestfind.cwl
@@ -1,0 +1,31 @@
+# This is a manually created example file for the task in AAv1 called epestfind
+# example: 1 input, 1 output
+class: CommandLineTool
+cwlVersion: v1.2
+baseCommand:
+  - /home/dbuchan/Applications/EMBOSS-6.4.0/emboss/epestfind
+arguments:
+  - prefix: -graph
+    valueFrom: "NO"
+  - prefix: -window
+    valueFrom: "10"
+  - prefix: -order
+    valueFrom: "2"
+  - prefix: -threshold
+    valueFrom: "5.0"
+  - valueFrom: "$(runtime.tmpdir)/$ID/$(inputs.input_file.basename)"
+  - valueFrom: "$O1"
+    prefix: -outfile
+
+inputs:
+  input_file:
+    type: File
+    inputBinding:
+      format: ".sing"
+outputs:
+  output_file:
+    type: File
+    outputBinding:
+      glob: "*.pest"
+
+stdout: "*.stdout"


### PR DESCRIPTION
**!! This feature may need to be discussed with our client !!**
There exist some case in the dummy database that when `$TMP/$ID` occur, the input parameter `$I{num}` wont occur separately in the executable command. For example:
![image](https://github.com/psipred/analytics_automated/assets/100745292/07daadb3-0e81-4b33-ab60-63e428745f64)
and
![image](https://github.com/psipred/analytics_automated/assets/100745292/18c5ce85-c4a5-488e-85ed-747ce0040809)
This may be due to the fact that the previous task had all the input files in the `$TMP/$ID` directory.

So I currently assume that in such a case, the clt parser will not automatically add the input files to the execution command (which means, it will not automatically generate `$I1`, `$I2`, etc. and add to the `executable`). Unless the user specifies $(input.input_field_name.basename) **directly** in the **arguments field**.
