### PR TITLE
Handle software hint and add custom field for configuration table

### DIFF
--- a/analytics_automated/cwl_utils/cwl_clt_handler.py
+++ b/analytics_automated/cwl_utils/cwl_clt_handler.py
@@ -15,6 +15,11 @@ NOT_TASK_REQUIREMENTS = [
 ]
 dynamic_input_file_pattern = r"input.[^_]+.basename"
 FORMAT_MAP = r"analytics_automated/cwl_utils/format_uri_mapping.json"
+CONFIGURATION_CHOICES = {
+    "Software": 0,
+    "Dataset": 1,
+    "Misc.": 2,
+}
 
 # Feature Need to be discussed
 ADD_INPUT_FIELD = True
@@ -55,17 +60,27 @@ def handle_hint_software_hint(requirements: list) -> list:
                 if isinstance(s_packages, dict):
                     software_req_li = []
                     for p_name, p_attr in s_packages.items():
-                        p_attr['package'] = p_name
+                        p_attr['name'] = p_name
                         p_attr['version'] = ",".join(p_attr.get('version', ""))
+                        p_attr['type'] = "Software"
                         software_req_li.append(p_attr)
                     return software_req_li
                 if isinstance(s_packages, list):
                     for p in s_packages:
+                        p['name'] = p['package']
                         p['version'] = ",".join(p['version'])
+                        p['type'] = "Software"
                     return s_packages
     except Exception as e:
         logging.error(f"Error handling software package requirements: {e}")
     return []
+
+
+def handle_aa_custom_configuration(configrations: list) -> list:
+    for config in configrations:
+        if config.get('name') is None:
+            raise ValueError("The name of Configuration object should not be empty!")
+    return configrations
 
 
 def parse_cwl_clt(cwl_data, name, workflow_req: list = None):
@@ -123,7 +138,8 @@ def parse_cwl_clt(cwl_data, name, workflow_req: list = None):
             if re.search(dynamic_input_file_pattern, value):
                 parts = value.split('.')
                 if len(parts) <= 2:
-                    raise ValueError(f"Value '{value}' is not in the expected format 'inputs.input_field_name.basename'")
+                    raise ValueError(
+                        f"Value '{value}' is not in the expected format 'inputs.input_field_name.basename'")
                 input_name = parts[1]
                 if not input_name in input_li:
                     raise ValueError(f"Unexpected input field {input_name}, should be in {input_li}")
@@ -172,7 +188,15 @@ def parse_cwl_clt(cwl_data, name, workflow_req: list = None):
             custom_exit_status = DEFAULT_CUSTOM_EXIT_STATUS
 
     except Exception as e:
-        logging.error(f"Failed to parse custom fields for task {name}: {e}")
+        logging.error(f"Failed to parse custom exit behaviour fields for task {name}: {e}")
+
+    aa_task_config_li = []
+    software_hints = []
+    try:
+        aa_task_config_li = handle_aa_custom_configuration(cwl_data.get("AAConfiguration", []))
+        software_hints = handle_hint_software_hint(hints)
+    except Exception as e:
+        logging.error(f"Failed to parse custom configration fields for task {name}: {e}")
 
     task = {
         "name": name,
@@ -182,7 +206,7 @@ def parse_cwl_clt(cwl_data, name, workflow_req: list = None):
         "requirements": requirements,
         "environments": handle_env_variable_req(requirements),
         "hints": hints,
-        "configurations": handle_hint_software_hint(hints),
+        "configurations": aa_task_config_li + software_hints,
         "arguments": arguments,
         "stdin": stdin,
         "stdout": stdout,
@@ -227,7 +251,7 @@ def parse_cwl_clt(cwl_data, name, workflow_req: list = None):
                         ADD_INPUT_FIELD = False
                 else:
                     argument_str = dynamic_value_judge(input_li=task_name_li, max_out=max_out,
-                                                                value=argument)
+                                                       value=argument)
                 if not argument_separate and argument_prefix:
                     argument_str = argument_prefix + argument_str
                 elif argument_separate and argument_prefix:
@@ -418,11 +442,11 @@ def save_task_to_db(task_data, messages):
 
         for package in task_data['configurations']:
             try:
-                Configuration.objects.create(
+                c = Configuration.objects.create(
                     task=task,
-                    type=0,
-                    name=package['package'],
-                    version=package.get('version',None),
+                    type=CONFIGURATION_CHOICES.get(package.get('type'), 0),
+                    name=package['name'],
+                    version=package.get('version', None),
                     parameters=package.get('parameter', None)
                 )
             except Exception as e:

--- a/analytics_automated/tests/example_cwl_files/create_fasta_S01.cwl
+++ b/analytics_automated/tests/example_cwl_files/create_fasta_S01.cwl
@@ -1,0 +1,22 @@
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: [python, /home/dbuchan/Code/bioserf/bin/make_fasta.py]
+hints:
+  - class: SoftwareRequirement
+    packages:
+      - package: "createfasta"
+        version: ["1.0"]
+
+inputs:
+  input_file:
+    type: File
+    inputBinding:
+      position: 2
+
+outputs:
+  output_fasta:
+    type: File
+    outputBinding:
+      glob: "*.fasta"
+
+stdout: "$(inputs.input_file.basename).fasta"

--- a/analytics_automated/tests/example_cwl_files/create_fasta_S02.cwl
+++ b/analytics_automated/tests/example_cwl_files/create_fasta_S02.cwl
@@ -1,0 +1,22 @@
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: [python, /home/dbuchan/Code/bioserf/bin/make_fasta.py]
+hints:
+  - class: SoftwareRequirement
+    packages:
+      createfasta:
+        version: ["1.0"]
+
+inputs:
+  input_file:
+    type: File
+    inputBinding:
+      position: 2
+
+outputs:
+  output_fasta:
+    type: File
+    outputBinding:
+      glob: "*.fasta"
+
+stdout: "$(inputs.input_file.basename).fasta"

--- a/analytics_automated/tests/example_cwl_files/run_legacy_psiblast_S1.cwl
+++ b/analytics_automated/tests/example_cwl_files/run_legacy_psiblast_S1.cwl
@@ -1,0 +1,31 @@
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: [python, /home/dbuchan/Code/blast_cache/scripts/run_legacy_blast.py, $TMP/$ID, http://127.1.2.1, /home/dbuchan/Applications/blast-2.2.26/bin, /home/dbuchan/Data/uniref_test_db/uniref_test.fasta, chk, -b, 0, -j, 3, -h, 0.001, -v, 5000]
+
+inputs:
+  input_fasta_file:
+    type: File
+    format: "http://edamontology.org/format_1929"
+    inputBinding:
+      position: 2
+
+outputs:
+  output_mtx:
+    type: File
+    outputBinding:
+      glob: "*.mtx"
+  output_chk:
+    type: File
+    outputBinding:
+      glob: "*.chk"
+
+AAConfiguration:
+  - name: psiblast
+    type: Software
+    parameters: "-b 0 -j 3 -h 0.001 -v 5000"
+    version: 2.23.2
+  - name: uniref90
+    type: Dataset
+    version: 2023
+
+stdout: "$(inputs.input_file.basename).bls"

--- a/analytics_automated/tests/test_cwl_parser.py
+++ b/analytics_automated/tests/test_cwl_parser.py
@@ -19,12 +19,12 @@ class CWLParserTest(TestCase):
         this_backend = add_fake_backend(name="local1", root_path="/tmp/")
         base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         # filenames = ['task1', 'task2', 'task3', 'task4', 'workflow']
-        filenames = ['psipass22']
+        filenames = ['create_fasta_S01', 'create_fasta_S02']
         message = []
         for filename in filenames:
             file_path = os.path.join(base_dir, 'tests', 'example_cwl_files', f'{filename}.cwl')
             read_cwl_file(file_path, filename, message)
-            print(message)
+            print(f"[{filename} Message]", message[-1])
         # result = read_cwl_file(file_path, filename, message)
         # self.assertIsNotNone(result)
 

--- a/analytics_automated/tests/test_cwl_parser.py
+++ b/analytics_automated/tests/test_cwl_parser.py
@@ -19,7 +19,7 @@ class CWLParserTest(TestCase):
         this_backend = add_fake_backend(name="local1", root_path="/tmp/")
         base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         # filenames = ['task1', 'task2', 'task3', 'task4', 'workflow']
-        filenames = ['create_fasta_S01', 'create_fasta_S02']
+        filenames = ['create_fasta_S01', 'run_legacy_psiblast_S1']
         message = []
         for filename in filenames:
             file_path = os.path.join(base_dir, 'tests', 'example_cwl_files', f'{filename}.cwl')


### PR DESCRIPTION
- Handle the softwareRequirement in the hint field in CWL file, convert to the record in `analytics_automated_configuration` table.
   - The `specs` will not be written in the table
- Adding a custom field called `AAConfiguration`:
  - contains four field
``` yaml
AAConfiguration:
  - name: string
    type: int
    parameters: string
    version: string
````