### PR TITLE
quick fix baseCommand position Error

### DIFF
--- a/analytics_automated/cwl_utils/cwl_clt_handler.py
+++ b/analytics_automated/cwl_utils/cwl_clt_handler.py
@@ -1,7 +1,5 @@
 import logging
 import json
-import re
-import string
 from ..models import Backend, Task, Parameter, Environment, Configuration
 
 logger = logging.getLogger(__name__)
@@ -131,7 +129,17 @@ def parse_cwl_clt(cwl_data, name, workflow_req: list = None):
         return parsed_outputs
 
     logging.info(f"Parsing CWL command line tool: {name}")
-    base_command = cwl_data.get("baseCommand")
+
+    try:
+        base_command_ini = cwl_data.get("baseCommand")
+        if isinstance(base_command_ini, list):
+            base_command = ' '.join(base_command_ini)
+        else:
+            base_command = base_command_ini
+        del base_command_ini
+    except Exception as e:
+        logging.error(f"Error parsing CWL baseCommand: {e}")
+
     inputs = cwl_data.get("inputs", {})
     outputs = cwl_data.get("outputs", {})
     requirements = cwl_data.get("requirements", [])
@@ -185,10 +193,7 @@ def parse_cwl_clt(cwl_data, name, workflow_req: list = None):
     else:
         task['stdout_glob'] = ""
 
-    if isinstance(base_command, list):
-        executable_parts = base_command
-    else:
-        executable_parts = [base_command]
+    executable_parts = [base_command]
 
     try:
         for argument_item in arguments:


### PR DESCRIPTION
The baseCommand field will always appear in the final command line before the parameters.
https://www.commonwl.org/user_guide/topics/inputs.html 
Thus, changed current ctl parser.
Input:
`s4pred.cwl`
``` yaml
cwlVersion: v1.2
class: CommandLineTool

baseCommand: [python3, "/home/dbuchan/Code/s4pred/run_model.py"]

stdout: out.horiz

inputs:
  output_flag:
    type: string
    default: "horiz"
    inputBinding:
      position: 1
      prefix: -t
  threads:
    type: string
    default: "1"
    inputBinding:
      position: 2
      prefix: -T
  fa_file:
    type: string
    inputBinding:
      position: 3

outputs:
  s4pred_output:
    type: stdout
```

Executable Before:
`python3 $P1 $P2 $P3 /home/dbuchan/Code/s4pred/run_model.py `
Fixed:
`python3 /home/dbuchan/Code/s4pred/run_model.py $P1 $P2 $P3`